### PR TITLE
Removed FileZilla

### DIFF
--- a/resource.html
+++ b/resource.html
@@ -15,7 +15,6 @@ permalink: /resources/
 
 <ul>
   <li><a href="http://brackets.io/">Brackets Editor</a>: Free HTML/CSS/Javascript Editor from Adobe</li>
-  <li><a href="https://filezilla-project.org/">FileZilla FTP Client</a>: Free cross-platform FTP software</li>
   <li><a href="https://www.google.com/chrome/">Chrome Browser</a>: Google Chrome Browser + Developer Tools</li>
   <li><a href="http://msysgit.github.io/">Git for Windows</a>: Free git client for windows with shell and graphical interfaces.</li>
   <li>Github Client <a href="https://windows.github.com/">Windows</a> or <a href="https://mac.github.com/">Mac</a>: Free git/github client</li>


### PR DESCRIPTION
We found the FileZilla installer had a lot of extra malware so we are removing it. We will add another FTP client later.
